### PR TITLE
Only add defined variables to SC.MODULE_INFO

### DIFF
--- a/templates/module.ejs
+++ b/templates/module.ejs
@@ -2,8 +2,8 @@
 if (!SC.MODULE_INFO["<%= name %>"]) {
   SC.MODULE_INFO["<%= name %>"] = SC.Object.create({
     styles: <%- styles %>,
-    scriptURL: "<%= scriptURL %>",
-    stringURL: "<%= stringURL %>",
-    source: <%= scriptSource %>
+    scriptURL: "<%= scriptURL %>"<%if (locals.stringURL) { %>,
+    stringURL: "<%= stringURL %>"<% } %><%if (locals.scriptSource) { %>,
+    source: <%= scriptSource %><% } %>
   });
 }


### PR DESCRIPTION
Currently `stringURL` and `scriptSource` are not implemented. To prevent SC.MODULE_INFO from nor working, we first check those variables are defined before including them.

Another solution may be to revert https://github.com/sproutcore/build-tools/commit/ad1e5c320e404e1ddce66562728e42c22eba234f until this properties are implemented.